### PR TITLE
Use Composer and Node as manager names

### DIFF
--- a/src/PackageManager/AbstractPackageManager.php
+++ b/src/PackageManager/AbstractPackageManager.php
@@ -4,12 +4,7 @@ namespace DepDoc\PackageManager;
 
 abstract class AbstractPackageManager
 {
-    public function getName()
-    {
-        $fullyQualifiedClassNameParts = explode('\\', get_called_class());
-
-        return end($fullyQualifiedClassNameParts);
-    }
+    abstract public function getName();
 
     abstract public function getInstalledPackages(string $directory);
 }

--- a/src/PackageManager/ComposerPackageManager.php
+++ b/src/PackageManager/ComposerPackageManager.php
@@ -45,4 +45,9 @@ class ComposerPackageManager extends AbstractPackageManager
 
         return $result;
     }
+
+    public function getName()
+    {
+        return 'Composer';
+    }
 }

--- a/src/PackageManager/NodePackageManager.php
+++ b/src/PackageManager/NodePackageManager.php
@@ -41,4 +41,9 @@ class NodePackageManager extends AbstractPackageManager
 
         return $result;
     }
+
+    public function getName()
+    {
+        return 'Node';
+    }
 }

--- a/tests/PackageManager/AbstractPackageManagerTest.php
+++ b/tests/PackageManager/AbstractPackageManagerTest.php
@@ -10,6 +10,6 @@ class AbstractPackageManagerTest extends TestCase
     public function testGetName()
     {
         $testDouble = new AbstractPackageManagerTestDouble();
-        $this->assertEquals('AbstractPackageManagerTestDouble', $testDouble->getName());
+        $this->assertEquals('Test', $testDouble->getName());
     }
 }

--- a/tests/PackageManager/AbstractPackageManagerTestDouble.php
+++ b/tests/PackageManager/AbstractPackageManagerTestDouble.php
@@ -7,6 +7,10 @@ use DepDoc\PackageManager\AbstractPackageManager;
 
 class AbstractPackageManagerTestDouble extends AbstractPackageManager
 {
+    public function getName()
+    {
+        return 'Test';
+    }
 
     public function getInstalledPackages(string $directory)
     {


### PR DESCRIPTION
This currently introduced a bug for existing applications.
The package manager name was used in the `DEPENDENCIES.md` and therefore must match again.