### PR TITLE
Add strict mode to validate command

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -6,7 +6,7 @@
 ## php-mock/php-mock-prophecy `0.0.2` [link](https://packagist.org/packages/php-mock/php-mock-prophecy)
 > Mock built-in PHP functions (e.g. time()) with Prophecy. This package relies on PHP's namespace fallback policy. No further extension is needed.
 
-## phpunit/phpunit `7.4.5` [link](https://packagist.org/packages/phpunit/phpunit)
+## phpunit/phpunit `7.5.1` [link](https://packagist.org/packages/phpunit/phpunit)
 > The PHP Unit Testing framework.
 
 ## symfony/console `v4.2.1` [link](https://packagist.org/packages/symfony/console)
@@ -23,6 +23,9 @@
 
 ## symfony/yaml `v4.2.1` [link](https://packagist.org/packages/symfony/yaml)
 > Symfony Yaml Component
+
+## vierbergenlars/php-semver `3.0.2` [link](https://packagist.org/packages/vierbergenlars/php-semver)
+> The Semantic Versioner for PHP
 
 ## zendframework/zend-servicemanager `3.3.2` [link](https://packagist.org/packages/zendframework/zend-servicemanager)
 > Factory-Driven Dependency Injection Container

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,33 +1,36 @@
 # Composer
 
-## composer/composer `1.7.3` [link](https://packagist.org/packages/composer/composer)
+## composer/composer `1.8.0` [link](https://packagist.org/packages/composer/composer)
 > Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.
 
 ## php-mock/php-mock-prophecy `0.0.2` [link](https://packagist.org/packages/php-mock/php-mock-prophecy)
 > Mock built-in PHP functions (e.g. time()) with Prophecy. This package relies on PHP's namespace fallback policy. No further extension is needed.
 
-## phpunit/phpunit `7.4.4` [link](https://packagist.org/packages/phpunit/phpunit)
+## phpunit/phpunit `7.5.1` [link](https://packagist.org/packages/phpunit/phpunit)
 > The PHP Unit Testing framework.
 
 ## symfony/config `v4.2.1` [link](https://packagist.org/packages/symfony/config)
 > Symfony Config Component
 
-## symfony/console `v4.1.7` [link](https://packagist.org/packages/symfony/console)
+## symfony/console `v4.2.1` [link](https://packagist.org/packages/symfony/console)
 > Symfony Console Component
 
 ## symfony/dependency-injection `v4.2.1` [link](https://packagist.org/packages/symfony/dependency-injection)
 > Symfony DependencyInjection Component
 
-## symfony/property-access `v4.1.7` [link](https://packagist.org/packages/symfony/property-access)
+## symfony/property-access `v4.2.1` [link](https://packagist.org/packages/symfony/property-access)
 > Symfony PropertyAccess Component
 
-## symfony/serializer `v4.1.7` [link](https://packagist.org/packages/symfony/serializer)
+## symfony/serializer `v4.2.1` [link](https://packagist.org/packages/symfony/serializer)
 > Symfony Serializer Component
 
-## symfony/var-dumper `v4.1.7` [link](https://packagist.org/packages/symfony/var-dumper)
+## symfony/var-dumper `v4.2.1` [link](https://packagist.org/packages/symfony/var-dumper)
 > Symfony mechanism for exploring and dumping PHP variables
 
-## symfony/yaml `v4.1.7` [link](https://packagist.org/packages/symfony/yaml)
+## symfony/yaml `v4.2.1` [link](https://packagist.org/packages/symfony/yaml)
 > Symfony Yaml Component
+
+## vierbergenlars/php-semver `3.0.2` [link](https://packagist.org/packages/vierbergenlars/php-semver)
+> The Semantic Versioner for PHP
 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use strict modes to verify your package version matches the documented dependenc
 ```
 ./vendor/bin/depdoc validate --strict
 ```
-Checks for major and minor version to match, i.e. installed 1.0.1 and documented 1.0.0 will bypass validation.
+Checks for major and minor version to match, i.e. installed **1.0.1** and documented **1.0.0** will bypass validation but installed **1.1.0** and documented **1.0.0** won't.
 
 ```
 ./vendor/bin/depdoc validate --very-strict

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ By adding a lock emoji (🔒) after the version number, you can document that th
 ```
 
 Validates that every installed dependency is documented in DEPENDENCIES.md. Also makes sure that no package surpasses its locked version.
+
+Use strict modes to verify your package version matches the documented dependencies.
+
+```
+./vendor/bin/depdoc validate --strict
+```
+Checks for major and minor version to match, i.e. installed 1.0.1 and documented 1.0.0 will bypass validation.
+
+```
+./vendor/bin/depdoc validate --very-strict
+```
+Checks for full semantic versioning match, i.e. installed 1.0.1 and documented 1.0.0 will not bypass validation.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/serializer": "^4.1",
         "symfony/property-access": "^4.1",
         "zendframework/zend-servicemanager": "^3.3",
-        "composer/composer": "^1.7"
+        "composer/composer": "^1.7",
+        "vierbergenlars/php-semver": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",

--- a/src/Command/ValidateCommand.php
+++ b/src/Command/ValidateCommand.php
@@ -6,7 +6,9 @@ namespace DepDoc\Command;
 use DepDoc\Parser\MarkdownParser;
 use DepDoc\Parser\ParserInterface;
 use DepDoc\Validator\PackageValidator;
+use DepDoc\Validator\StrictMode;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ValidateCommand extends BaseCommand
@@ -35,6 +37,22 @@ class ValidateCommand extends BaseCommand
         parent::configure();
 
         $this->setDescription('Validate a already generated DEPENDENCIES.md');
+
+        $this->addOption(
+            '--strict',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Strict mode checks for major and minor versions',
+            false
+        );
+
+        $this->addOption(
+            '--very-strict',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Very strict mode checks for full semantic versioning match',
+            false
+        );
     }
 
     /**
@@ -63,7 +81,11 @@ class ValidateCommand extends BaseCommand
         $installedPackages = $this->getInstalledPackages($directory);
         $dependencyList = $this->parser->getDocumentedDependencies($filepath);
 
-        $validationResult = $this->validator->compare($installedPackages, $dependencyList);
+        $validationResult = $this->validator->compare(
+            $this->getStrictMode($input),
+            $installedPackages,
+            $dependencyList
+        );
         if (empty($validationResult)) {
             if ($this->io->isVerbose()) {
                 $this->io->writeln('Validation result: empty, all fine.');
@@ -82,5 +104,18 @@ class ValidateCommand extends BaseCommand
         }
 
         return -1;
+    }
+
+    protected function getStrictMode(InputInterface $input): StrictMode
+    {
+        if ($input->getOption('very-strict') !== false) {
+            return StrictMode::fullSemVerMatch();
+        }
+
+        if ($input->getOption('strict') !== false) {
+            return StrictMode::majorAndMinor();
+        }
+
+        return StrictMode::existingOrLocked();
     }
 }

--- a/src/Validator/StrictMode.php
+++ b/src/Validator/StrictMode.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DepDoc\Validator;
+
+class StrictMode
+{
+    protected const EXISTING_OR_LOCKED = 0;
+    protected const MAJOR_AND_MINOR = 1;
+    protected const FULL_SEM_VER_MATCH = 2;
+
+    /** @var int */
+    private $mode;
+
+    /**
+     * @param int $mode
+     */
+    protected function __construct(int $mode)
+    {
+        $this->mode = $mode;
+    }
+
+    public static function existingOrLocked(): self
+    {
+        return new StrictMode(self::EXISTING_OR_LOCKED);
+    }
+
+    public static function majorAndMinor(): self
+    {
+        return new StrictMode(self::MAJOR_AND_MINOR);
+    }
+
+    public static function fullSemVerMatch(): self
+    {
+        return new StrictMode(self::FULL_SEM_VER_MATCH);
+    }
+
+    public function isExistingOrLocked(): bool
+    {
+        return $this->mode === self::EXISTING_OR_LOCKED;
+    }
+
+    public function isMajorAndMinor(): bool
+    {
+        return $this->mode === self::MAJOR_AND_MINOR;
+    }
+
+    public function isFullSemVerMatch(): bool
+    {
+        return $this->mode === self::FULL_SEM_VER_MATCH;
+    }
+}

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -110,12 +110,7 @@ class ValidateCommandTest extends TestCase
             ->willReturn($packages->reveal())
             ->shouldBeCalled();
 
-        $parser = $this->prophesize(ParserInterface::class);
-        $parser->getDocumentedDependencies(
-            Argument::type('string')
-        )->willReturn(
-            $this->prophesize(PackageManagerPackageList::class)->reveal()
-        );
+        $parser = $this->getDefaultParser();
 
         $validator = $this->prophesize(PackageValidator::class);
         $validator
@@ -140,17 +135,7 @@ class ValidateCommandTest extends TestCase
         $input->getOption('directory')->willReturn('/test');
         $input->getOption('very-strict')->willReturn('');
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
-            ->file_exists(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $prophecy
-            ->realpath(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-
-        $prophecy->reveal();
+        $this->prophesizeSystemCalls();
 
         $this->assertEquals(
             0,
@@ -162,32 +147,10 @@ class ValidateCommandTest extends TestCase
 
     public function testItDeterminesVeryStrictMode(): void
     {
-        $packages = $this->prophesize(PackageManagerPackageList::class);
-        $packages
-            ->getAllFlat()
-            ->willReturn([])
-            ->shouldBeCalled();
+        $composerPackageManager = $this->getDefaultComposerPackageManager();
+        $nodePackageManager = $this->getDefaultNodePackageManager();
 
-        $composerPackageManager = $this->prophesize(
-            ComposerPackageManager::class
-        );
-        $composerPackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $nodePackageManager = $this->prophesize(NodePackageManager::class);
-        $nodePackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $parser = $this->prophesize(ParserInterface::class);
-        $parser->getDocumentedDependencies(
-            Argument::type('string')
-        )->willReturn(
-            $this->prophesize(PackageManagerPackageList::class)->reveal()
-        );
+        $parser = $this->getDefaultParser();
 
         $validator = $this->prophesize(PackageValidator::class);
         $validator
@@ -216,21 +179,12 @@ class ValidateCommandTest extends TestCase
         $input->getOption('directory')->willReturn('/test');
         $input->getOption('very-strict')->willReturn('');
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
-            ->file_exists(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $prophecy
-            ->realpath(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-
-        $prophecy->reveal();
+        $this->prophesizeSystemCalls();
 
         $this->assertEquals(
             0,
-            $command->run($input->reveal(), $output->reveal())
+            $command->run($input->reveal(), $output->reveal()),
+            'exit code should match'
         );
 
         $this->prophet->checkPredictions();
@@ -238,32 +192,10 @@ class ValidateCommandTest extends TestCase
 
     public function testItDeterminesStrictMode(): void
     {
-        $packages = $this->prophesize(PackageManagerPackageList::class);
-        $packages
-            ->getAllFlat()
-            ->willReturn([])
-            ->shouldBeCalled();
+        $composerPackageManager = $this->getDefaultComposerPackageManager();
+        $nodePackageManager = $this->getDefaultNodePackageManager();
 
-        $composerPackageManager = $this->prophesize(
-            ComposerPackageManager::class
-        );
-        $composerPackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $nodePackageManager = $this->prophesize(NodePackageManager::class);
-        $nodePackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $parser = $this->prophesize(ParserInterface::class);
-        $parser->getDocumentedDependencies(
-            Argument::type('string')
-        )->willReturn(
-            $this->prophesize(PackageManagerPackageList::class)->reveal()
-        );
+        $parser = $this->getDefaultParser();
 
         $validator = $this->prophesize(PackageValidator::class);
         $validator
@@ -293,21 +225,12 @@ class ValidateCommandTest extends TestCase
         $input->getOption('very-strict')->willReturn(false);
         $input->getOption('strict')->willReturn('')->shouldBeCalled();
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
-            ->file_exists(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $prophecy
-            ->realpath(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-
-        $prophecy->reveal();
+        $this->prophesizeSystemCalls();
 
         $this->assertEquals(
             0,
-            $command->run($input->reveal(), $output->reveal())
+            $command->run($input->reveal(), $output->reveal()),
+            'exit code should match'
         );
 
         $this->prophet->checkPredictions();
@@ -315,32 +238,10 @@ class ValidateCommandTest extends TestCase
 
     public function testItDeterminesDefaultStrictMode(): void
     {
-        $packages = $this->prophesize(PackageManagerPackageList::class);
-        $packages
-            ->getAllFlat()
-            ->willReturn([])
-            ->shouldBeCalled();
+        $composerPackageManager = $this->getDefaultComposerPackageManager();
+        $nodePackageManager = $this->getDefaultNodePackageManager();
 
-        $composerPackageManager = $this->prophesize(
-            ComposerPackageManager::class
-        );
-        $composerPackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $nodePackageManager = $this->prophesize(NodePackageManager::class);
-        $nodePackageManager
-            ->getInstalledPackages(Argument::type('string'))
-            ->willReturn($packages->reveal())
-            ->shouldBeCalled();
-
-        $parser = $this->prophesize(ParserInterface::class);
-        $parser->getDocumentedDependencies(
-            Argument::type('string')
-        )->willReturn(
-            $this->prophesize(PackageManagerPackageList::class)->reveal()
-        );
+        $parser = $this->getDefaultParser();
 
         $validator = $this->prophesize(PackageValidator::class);
         $validator
@@ -370,21 +271,12 @@ class ValidateCommandTest extends TestCase
         $input->getOption('very-strict')->willReturn(false);
         $input->getOption('strict')->willReturn(false);
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
-            ->file_exists(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-        $prophecy
-            ->realpath(Argument::type('string'))
-            ->shouldBeCalledTimes(1)
-            ->willReturn(true);
-
-        $prophecy->reveal();
+        $this->prophesizeSystemCalls();
 
         $this->assertEquals(
             0,
-            $command->run($input->reveal(), $output->reveal())
+            $command->run($input->reveal(), $output->reveal()),
+            'exit code should match'
         );
 
         $this->prophet->checkPredictions();
@@ -423,5 +315,71 @@ class ValidateCommandTest extends TestCase
         $output->isVeryVerbose()->willReturn(false);
 
         return $output;
+    }
+
+    protected function getDefaultComposerPackageManager()
+    {
+        $packages = $this->prophesize(PackageManagerPackageList::class);
+        $packages
+            ->getAllFlat()
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $composerPackageManager = $this->prophesize(
+            ComposerPackageManager::class
+        );
+        $composerPackageManager
+            ->getInstalledPackages(Argument::type('string'))
+            ->willReturn($packages->reveal())
+            ->shouldBeCalled();
+
+        return $composerPackageManager;
+    }
+
+    protected function getDefaultNodePackageManager()
+    {
+        $packages = $this->prophesize(PackageManagerPackageList::class);
+        $packages
+            ->getAllFlat()
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $nodePackageManager = $this->prophesize(NodePackageManager::class);
+        $nodePackageManager
+            ->getInstalledPackages(Argument::type('string'))
+            ->willReturn($packages->reveal())
+            ->shouldBeCalled();
+
+        return $nodePackageManager;
+    }
+
+    /**
+     * @return ParserInterface|ObjectProphecy
+     */
+    protected function getDefaultParser()
+    {
+        $parser = $this->prophesize(ParserInterface::class);
+        $parser->getDocumentedDependencies(
+            Argument::type('string')
+        )->willReturn(
+            $this->prophesize(PackageManagerPackageList::class)->reveal()
+        );
+
+        return $parser;
+    }
+
+    protected function prophesizeSystemCalls(): void
+    {
+        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
+        $prophecy
+            ->file_exists(Argument::type('string'))
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+        $prophecy
+            ->realpath(Argument::type('string'))
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+
+        $prophecy->reveal();
     }
 }


### PR DESCRIPTION
Resolving issue (https://github.com/cheeZery/depdoc/issues/20).

Add --strict and --very-strict option to validate command.

Used foreign library to check for version.