### PR TITLE
Fix update command not validating lock

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -4,7 +4,7 @@ services:
         arguments: ['@PackageValidator', '@MarkdownParser', '@ComposerPackageManager', '@NodePackageManager', '@ConfigurationService']
     UpdateCommand:
         class: \DepDoc\Command\UpdateCommand
-        arguments: ['@MarkdownWriter', '@MarkdownParser', '@ComposerPackageManager', '@NodePackageManager', '@ConfigurationService']
+        arguments: ['@MarkdownWriter', '@MarkdownParser', '@PackageValidator', '@ComposerPackageManager', '@NodePackageManager', '@ConfigurationService']
 
     PackageValidator:
         class: \DepDoc\Validator\PackageValidator

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -92,7 +92,7 @@ class UpdateCommand extends BaseCommand
             $documentedDependencies
         );
 
-        if ($lockedVersionErrors) {
+        if (count($lockedVersionErrors) > 0) {
             foreach ($lockedVersionErrors as $error) {
                 $this->io->error($error->toString());
             }

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -85,7 +85,7 @@ class UpdateCommand extends BaseCommand
             $filepath
         );
 
-        // This checks for version which are locked but installed with a different version.
+        // This checks for versions which are locked but installed with a different version.
         $lockedVersionErrors = $this->packageValidator->compare(
             StrictMode::lockedOnly(),
             $installedPackages,

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -7,6 +7,8 @@ use DepDoc\Configuration\ConfigurationService;
 use DepDoc\PackageManager\ComposerPackageManager;
 use DepDoc\PackageManager\NodePackageManager;
 use DepDoc\Parser\ParserInterface;
+use DepDoc\Validator\PackageValidator;
+use DepDoc\Validator\StrictMode;
 use DepDoc\Writer\WriterInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,6 +19,8 @@ class UpdateCommand extends BaseCommand
     protected $writer;
     /** @var ParserInterface */
     protected $parser;
+    /** @var PackageValidator */
+    private $packageValidator;
 
     /**
      * @inheritdoc
@@ -24,6 +28,7 @@ class UpdateCommand extends BaseCommand
     public function __construct(
         WriterInterface $writer,
         ParserInterface $parser,
+        PackageValidator $packageValidator,
         ComposerPackageManager $managerComposer,
         NodePackageManager $managerNode,
         ConfigurationService $configurationService
@@ -32,6 +37,7 @@ class UpdateCommand extends BaseCommand
         $this->parser = $parser;
 
         parent::__construct('update', $managerComposer, $managerNode, $configurationService);
+        $this->packageValidator = $packageValidator;
     }
 
     /**
@@ -78,6 +84,21 @@ class UpdateCommand extends BaseCommand
         $documentedDependencies = $this->parser->getDocumentedDependencies(
             $filepath
         );
+
+        // This checks for version which are locked but installed with a different version.
+        $lockedVersionErrors = $this->packageValidator->compare(
+            StrictMode::lockedOnly(),
+            $installedPackages,
+            $documentedDependencies
+        );
+
+        if ($lockedVersionErrors) {
+            foreach ($lockedVersionErrors as $error) {
+                $this->io->error($error->toString());
+            }
+
+            return 1;
+        }
 
         $this->writer->getConfiguration()->setNewline(
             $this->configuration->getNewlineCharacter()

--- a/src/Validator/PackageValidator.php
+++ b/src/Validator/PackageValidator.php
@@ -30,7 +30,10 @@ class PackageValidator
 
         foreach ($installedPackages->getAllFlat() as $package) {
             if ($dependencyList->has($package->getManagerName(), $package->getName()) === false) {
-                $errors[] = new ErrorMissingDocumentationResult($package->getManagerName(), $package->getName());
+
+                if (!$mode->isLockedOnly()) {
+                    $errors[] = new ErrorMissingDocumentationResult($package->getManagerName(), $package->getName());
+                }
                 continue;
             }
 
@@ -46,6 +49,10 @@ class PackageValidator
                 );
                 continue;
             }
+        }
+
+        if ($mode->isLockedOnly()) {
+            return $errors;
         }
 
         foreach ($dependencyList->getAllFlat() as $dependency) {
@@ -73,7 +80,7 @@ class PackageValidator
         DependencyData $dependency,
         PackageManagerPackageInterface $package
     ): bool {
-        if ($mode->isExistingOrLocked()) {
+        if ($mode->isLockedOnly() || $mode->isExistingOrLocked()) {
             if ($dependency->isVersionLocked()) {
                 return $dependency->getVersion() === $package->getVersion();
             }

--- a/src/Validator/StrictMode.php
+++ b/src/Validator/StrictMode.php
@@ -6,9 +6,10 @@ namespace DepDoc\Validator;
 
 class StrictMode
 {
-    protected const EXISTING_OR_LOCKED = 0;
-    protected const MAJOR_AND_MINOR = 1;
-    protected const FULL_SEM_VER_MATCH = 2;
+    protected const LOCKED_ONLY = 0;
+    protected const EXISTING_OR_LOCKED = 1;
+    protected const MAJOR_AND_MINOR = 2;
+    protected const FULL_SEM_VER_MATCH = 3;
 
     /** @var int */
     private $mode;
@@ -19,6 +20,11 @@ class StrictMode
     protected function __construct(int $mode)
     {
         $this->mode = $mode;
+    }
+
+    public static function lockedOnly(): self
+    {
+        return new StrictMode(self::LOCKED_ONLY);
     }
 
     public static function existingOrLocked(): self
@@ -34,6 +40,11 @@ class StrictMode
     public static function fullSemVerMatch(): self
     {
         return new StrictMode(self::FULL_SEM_VER_MATCH);
+    }
+
+    public function isLockedOnly(): bool
+    {
+        return $this->mode === self::LOCKED_ONLY;
     }
 
     public function isExistingOrLocked(): bool

--- a/tests/Command/UpdateCommandTest.php
+++ b/tests/Command/UpdateCommandTest.php
@@ -11,6 +11,8 @@ use DepDoc\PackageManager\NodePackageManager;
 use DepDoc\PackageManager\Package\PackageManagerPackageInterface;
 use DepDoc\PackageManager\PackageList\PackageManagerPackageList;
 use DepDoc\Parser\ParserInterface;
+use DepDoc\Validator\PackageValidator;
+use DepDoc\Validator\StrictMode;
 use DepDoc\Writer\WriterConfiguration;
 use DepDoc\Writer\WriterInterface;
 use phpmock\MockRegistry;
@@ -42,6 +44,7 @@ class UpdateCommandTest extends TestCase
         $command = new UpdateCommand(
             $this->prophesize(WriterInterface::class)->reveal(),
             $this->prophesize(ParserInterface::class)->reveal(),
+            $this->prophesize(PackageValidator::class)->reveal(),
             $this->prophesize(ComposerPackageManager::class)->reveal(),
             $this->prophesize(NodePackageManager::class)->reveal(),
             $this->prophesize(ConfigurationService::class)->reveal()
@@ -66,6 +69,7 @@ class UpdateCommandTest extends TestCase
         $command = new UpdateCommand(
             $this->prophesize(WriterInterface::class)->reveal(),
             $this->prophesize(ParserInterface::class)->reveal(),
+            $this->prophesize(PackageValidator::class)->reveal(),
             $composerPackageManager->reveal(),
             $this->prophesize(NodePackageManager::class)->reveal(),
             $this->prophesize(ConfigurationService::class)->reveal()
@@ -128,9 +132,13 @@ class UpdateCommandTest extends TestCase
             Argument::type(PackageManagerPackageList::class)
         );
 
+        $packageValidator = $this->prophesize(PackageValidator::class);
+        $packageValidator->compare(Argument::type(StrictMode::class), Argument::cetera())->willReturn([]);
+
         $command = new UpdateCommand(
             $writer->reveal(),
             $parser->reveal(),
+            $packageValidator->reveal(),
             $composerPackageManager->reveal(),
             $nodePackageManager->reveal(),
             $this->prophesize(ConfigurationService::class)->reveal()

--- a/tests/Validator/StrictModeTest.php
+++ b/tests/Validator/StrictModeTest.php
@@ -9,6 +9,15 @@ use PHPUnit\Framework\TestCase;
 
 class StrictModeTest extends TestCase
 {
+    public function testLockedOnly(): void
+    {
+        $strictMode = StrictMode::lockedOnly();
+
+        $this->assertTrue(
+            $strictMode->isLockedOnly(),
+            'strict mode should be locked only'
+        );
+    }
     public function testExistingOrLocked(): void
     {
         $strictMode = StrictMode::existingOrLocked();


### PR DESCRIPTION
The problem is, that when you run the update command is does not check the locked versions.

Instead it just updates it, so this leads to wrong dependencies.