### PR TITLE
Support for npm v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /build/
 
 /composer.lock
+
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 php:
-  - '7.1'
-  - '7.2'
+  - '7.4'
   - master
 
 env:

--- a/bin/depdoc
+++ b/bin/depdoc
@@ -1,14 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-$composerAutoload = getcwd() . '/vendor/autoload.php';
-
-if (!file_exists($composerAutoload)) {
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(getcwd() . '/vendor/autoload.php')) {
+    require getcwd() . '/vendor/autoload.php';
+} else {
     echo 'Couldn\'t find composer, make sure to run script in project root!' . PHP_EOL;
     exit(1);
 }
-
-require $composerAutoload;
 
 array_shift($argv);
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "composer/composer": "^1.7",
         "symfony/config": "^4.2",
         "vierbergenlars/php-semver": "^3.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.4.0",
         "ext-json": "*",
         "ext-pcre": "*",
         "symfony/console": "^4.1",
@@ -37,6 +37,7 @@
         "vierbergenlars/php-semver": "^3.0"
     },
     "require-dev": {
+        "roave/security-advisories": "dev-latest",
         "phpunit/phpunit": "^7.2",
         "php-mock/php-mock-prophecy": "^0.0.2",
         "symfony/var-dumper": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,14 @@
         "symfony/dependency-injection": "^4.2",
         "composer/composer": "^1.7",
         "symfony/config": "^4.2",
-        "vierbergenlars/php-semver": "^3.0"
+        "vierbergenlars/php-semver": "^3.0",
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "phpunit/phpunit": "^7.2",
-        "php-mock/php-mock-prophecy": "^0.0.2",
-        "symfony/var-dumper": "^4.1",
-        "phpstan/phpstan": "^0.10.7",
-        "phpstan/phpstan-strict-rules": "^0.10.1"
+        "phpstan/phpstan": "^0.12.88",
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan-strict-rules": "^0.12.9",
+        "php-mock/php-mock-prophecy": "^0.1.0",
+        "symfony/var-dumper": "^4.1"
     }
 }

--- a/src/Application/ApplicationBuilder.php
+++ b/src/Application/ApplicationBuilder.php
@@ -14,26 +14,20 @@ class ApplicationBuilder
 {
     private const CONFIG_DIRECTORY = __DIR__ . '/../../config';
 
-    /**
-     * @var ContainerBuilder
-     */
-    private $containerBuilder;
-
-    /**
-     * @var LoaderInterface
-     */
-    private $loader;
+    private ContainerBuilder $containerBuilder;
+    private LoaderInterface $loader;
 
     public function __construct(
         ContainerBuilder $containerBuilder = null,
-        LoaderInterface $fileLoader = null
-    ) {
-        $this->containerBuilder = $containerBuilder ?: new ContainerBuilder();
-        $this->loader = $fileLoader ?: new YamlFileLoader(
-            $this->containerBuilder,
-            new FileLocator(self::CONFIG_DIRECTORY)
-        );
-
+        LoaderInterface  $fileLoader = null
+    )
+    {
+        $this->containerBuilder = $containerBuilder ?? new ContainerBuilder();
+        $this->loader = $fileLoader ??
+            new YamlFileLoader(
+                $this->containerBuilder,
+                new FileLocator(self::CONFIG_DIRECTORY)
+            );
     }
 
     public function build(): Application

--- a/src/Dependencies/DependencyData.php
+++ b/src/Dependencies/DependencyData.php
@@ -10,17 +10,15 @@ use DepDoc\PackageManager\Package\PackageManagerPackage;
  */
 class DependencyData extends PackageManagerPackage
 {
-    /** @var null|string */
-    protected $lockSymbol;
-    /** @var DependencyDataAdditionalContent */
-    protected $additionalContent;
+    protected ?string $lockSymbol;
+    protected DependencyDataAdditionalContent $additionalContent;
 
     /**
      * @param string $managerName
      * @param string $name
      * @param string $version
      * @param null|string $lockSymbol
-     * @param array $additionalContent
+     * @param string[] $additionalContent
      */
     public function __construct(
         string $managerName,
@@ -35,25 +33,16 @@ class DependencyData extends PackageManagerPackage
         $this->additionalContent = new DependencyDataAdditionalContent($additionalContent ?? []);
     }
 
-    /**
-     * @return null|string
-     */
     public function getLockSymbol(): ?string
     {
         return $this->lockSymbol;
     }
 
-    /**
-     * @return bool
-     */
     public function isVersionLocked(): bool
     {
         return $this->getLockSymbol() !== null;
     }
 
-    /**
-     * @return DependencyDataAdditionalContent
-     */
     public function getAdditionalContent(): DependencyDataAdditionalContent
     {
         return $this->additionalContent;

--- a/src/Dependencies/DependencyDataAdditionalContent.php
+++ b/src/Dependencies/DependencyDataAdditionalContent.php
@@ -9,7 +9,7 @@ namespace DepDoc\Dependencies;
 class DependencyDataAdditionalContent
 {
     /** @var string[] */
-    protected $lines = [];
+    protected array $lines = [];
 
     /**
      * @param string[] $lines
@@ -20,6 +20,9 @@ class DependencyDataAdditionalContent
     }
 
 
+    /**
+     * @return string[]
+     */
     public function getAll(): array
     {
         return $this->lines;

--- a/src/PackageManager/Factory/ComposerPackageManagerFactory.php
+++ b/src/PackageManager/Factory/ComposerPackageManagerFactory.php
@@ -13,7 +13,7 @@ class ComposerPackageManagerFactory
     public static function create(Factory $factory = null): ComposerPackageManager
     {
         // Find a better way to create composer package with ConsoleIO.
-        $factory = $factory ?: new Factory();
+        $factory = $factory ?? new Factory();
 
         return new ComposerPackageManager(
             $factory->createComposer(new NullIO())

--- a/src/PackageManager/NodePackageManager.php
+++ b/src/PackageManager/NodePackageManager.php
@@ -6,6 +6,7 @@ namespace DepDoc\PackageManager;
 use DepDoc\PackageManager\Exception\FailedToParseDependencyInformationException;
 use DepDoc\PackageManager\Package\NodePackage;
 use DepDoc\PackageManager\PackageList\PackageManagerPackageList;
+use JsonException;
 
 class NodePackageManager implements PackageManagerInterface
 {
@@ -30,17 +31,17 @@ class NodePackageManager implements PackageManagerInterface
 
         $output = trim($output);
 
-        if (strlen($output) === 0 || $output[0] !== '{') {
+        if ($output === '' || $output[0] !== '{') {
             return $packageList;
         }
 
-        $dependencies = json_decode($output, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        try {
+            $dependencies = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
             throw new FailedToParseDependencyInformationException(
                 $this->getName(),
-                json_last_error(),
-                json_last_error_msg()
+                $exception->getCode(),
+                $exception->getMessage()
             );
         }
 

--- a/src/PackageManager/NodePackageManager.php
+++ b/src/PackageManager/NodePackageManager.php
@@ -30,7 +30,7 @@ class NodePackageManager implements PackageManagerInterface
         );
         $output = shell_exec($command);
 
-        if ($output === null) {
+        if ($output === null || $output === false) {
             return $packageList;
         }
 
@@ -54,7 +54,7 @@ class NodePackageManager implements PackageManagerInterface
 
         $relevantData = array_flip(['name', 'version', 'description', 'peerMissing', 'extraneous']);
 
-        array_walk($installedPackages, static function (&$dependency) use ($relevantData) {
+        array_walk($installedPackages, static function (&$dependency) use ($relevantData): void {
             $dependency = array_intersect_key($dependency, $relevantData);
         });
 
@@ -74,6 +74,10 @@ class NodePackageManager implements PackageManagerInterface
         return $packageList;
     }
 
+    /**
+     * @param array{peerMissing?: array, extraneous?: bool} $installedPackage
+     * @return bool
+     */
     private function isValidPackage(array $installedPackage): bool
     {
         // NPM <= 6 peer dependency note

--- a/src/PackageManager/NodePackageManager.php
+++ b/src/PackageManager/NodePackageManager.php
@@ -14,7 +14,15 @@ class NodePackageManager implements PackageManagerInterface
         $packageList = new PackageManagerPackageList();
 
         // @TODO: Support npm binary detection
-        $output = shell_exec("cd " . escapeshellarg($directory) . " && npm list -json -depth 0 -long");
+        $npmCommand = implode(' ', [
+            'npm list',
+            '--json',
+            // Saves some performance
+            '--depth 0',
+            // Required to get description field
+            '--long',
+        ]);
+        $output = shell_exec("cd " . escapeshellarg($directory) . " && " . $npmCommand . " 2> /dev/null");
 
         if ($output === null) {
             return $packageList;

--- a/src/PackageManager/NodePackageManager.php
+++ b/src/PackageManager/NodePackageManager.php
@@ -30,7 +30,7 @@ class NodePackageManager implements PackageManagerInterface
         );
         $output = shell_exec($command);
 
-        if ($output === null || $output === false) {
+        if (!is_string($output)) {
             return $packageList;
         }
 

--- a/src/PackageManager/Package/PackageManagerPackage.php
+++ b/src/PackageManager/Package/PackageManagerPackage.php
@@ -5,18 +5,10 @@ namespace DepDoc\PackageManager\Package;
 
 class PackageManagerPackage implements PackageManagerPackageInterface
 {
-    /** @var string */
-    protected $managerName;
-    /** @var string */
-    protected $name;
-    /** @var string */
-    protected $version;
+    protected string $managerName;
+    protected string $name;
+    protected string $version;
 
-    /**
-     * @param string $managerName
-     * @param string $name
-     * @param string $version
-     */
     public function __construct(string $managerName, string $name, string $version)
     {
         $this->managerName = $managerName;
@@ -24,41 +16,26 @@ class PackageManagerPackage implements PackageManagerPackageInterface
         $this->version = $version;
     }
 
-    /**
-     * @return string
-     */
     public function getManagerName(): string
     {
         return $this->managerName;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
     public function getVersion(): string
     {
         return $this->version;
     }
 
-    /**
-     * @return string
-     */
     public function getExternalLink(): string
     {
         throw new \RuntimeException(__CLASS__ . ' does not have an external url');
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/PackageManager/PackageList/PackageManagerPackageList.php
+++ b/src/PackageManager/PackageList/PackageManagerPackageList.php
@@ -9,32 +9,23 @@ use DepDoc\PackageManager\Package\PackageManagerPackageInterface;
 class PackageManagerPackageList implements PackageManagerPackageListInterface
 {
     /** @var PackageManagerPackage[][] */
-    protected $dependencies = [];
+    protected array $dependencies = [];
     /** @var null|PackageManagerPackage[] */
-    protected $cachedFlatDependencies;
+    protected ?array $cachedFlatDependencies;
 
-    /**
-     * @param PackageManagerPackageInterface $package
-     * @return PackageManagerPackageListInterface
-     */
-    public function add(PackageManagerPackageInterface $package): PackageManagerPackageListInterface
+    public function add(PackageManagerPackageInterface $data): PackageManagerPackageListInterface
     {
-        if (isset($this->dependencies[$package->getManagerName()]) === false) {
-            $this->dependencies[$package->getManagerName()] = [];
+        if (isset($this->dependencies[$data->getManagerName()]) === false) {
+            $this->dependencies[$data->getManagerName()] = [];
         }
 
         // @TODO: Check for same package name and throw exception in case somebody edits the file manually
-        $this->dependencies[$package->getManagerName()][$package->getName()] = $package;
+        $this->dependencies[$data->getManagerName()][$data->getName()] = $data;
         $this->cachedFlatDependencies = null;
 
         return $this;
     }
 
-    /**
-     * @param string $packageManagerName
-     * @param string $packageName
-     * @return bool
-     */
     public function has(string $packageManagerName, string $packageName): bool
     {
         if (isset($this->dependencies[$packageManagerName]) === false) {
@@ -44,12 +35,7 @@ class PackageManagerPackageList implements PackageManagerPackageListInterface
         return array_key_exists($packageName, $this->getAllByManager($packageManagerName));
     }
 
-    /**
-     * @param string $packageManagerName
-     * @param string $packageName
-     * @return null|PackageManagerPackageInterface
-     */
-    public function get(string $packageManagerName, string $packageName): ?PackageManagerPackageInterface
+    public function get(string $packageManagerName, string $packageName): ?PackageManagerPackage
     {
         if ($this->has($packageManagerName, $packageName) === false) {
             return null;
@@ -88,7 +74,7 @@ class PackageManagerPackageList implements PackageManagerPackageListInterface
 
     /**
      * @param string $manager
-     * @return PackageManagerPackageInterface[]
+     * @return PackageManagerPackage[]
      */
     public function getAllByManager(string $manager): array
     {
@@ -99,10 +85,6 @@ class PackageManagerPackageList implements PackageManagerPackageListInterface
         return $this->dependencies[$manager];
     }
 
-    /**
-     * @param PackageManagerPackageListInterface $packageList
-     * @return PackageManagerPackageListInterface
-     */
     public function merge(PackageManagerPackageListInterface $packageList): PackageManagerPackageListInterface
     {
         foreach ($packageList->getAllFlat() as $package) {

--- a/src/PackageManager/PackageList/PackageManagerPackageList.php
+++ b/src/PackageManager/PackageList/PackageManagerPackageList.php
@@ -11,7 +11,7 @@ class PackageManagerPackageList implements PackageManagerPackageListInterface
     /** @var PackageManagerPackage[][] */
     protected array $dependencies = [];
     /** @var null|PackageManagerPackage[] */
-    protected ?array $cachedFlatDependencies;
+    protected ?array $cachedFlatDependencies = null;
 
     public function add(PackageManagerPackageInterface $data): PackageManagerPackageListInterface
     {

--- a/src/Writer/MarkdownWriter.php
+++ b/src/Writer/MarkdownWriter.php
@@ -11,17 +11,12 @@ use DepDoc\PackageManager\PackageList\PackageManagerPackageList;
 
 class MarkdownWriter implements WriterInterface
 {
-    /** @var WriterConfiguration */
-    protected $configuration;
+    protected WriterConfiguration $configuration;
 
-    /**
-     * @param WriterConfiguration|null $configuration
-     */
     public function __construct(?WriterConfiguration $configuration = null)
     {
         $this->configuration = $configuration ?? new WriterConfiguration();
     }
-
 
     /**
      * @inheritdoc
@@ -71,25 +66,16 @@ class MarkdownWriter implements WriterInterface
 
         $documentation[] = "";
 
-        file_put_contents($filepath, array_map(function ($line) {
+        file_put_contents($filepath, array_map(function ($line): string {
             return $line . $this->configuration->getNewline();
         }, $documentation), LOCK_EX);
     }
 
-    /**
-     * @param string $packageManagerName
-     * @return string
-     */
     protected function createPackageManagerLine(string $packageManagerName): string
     {
         return "# $packageManagerName";
     }
 
-    /**
-     * @param PackageManagerPackageInterface $package
-     * @param DependencyData $dependency
-     * @return string
-     */
     protected function createPackageLockedLine(
         PackageManagerPackageInterface $package,
         DependencyData $dependency
@@ -102,10 +88,6 @@ class MarkdownWriter implements WriterInterface
         return $line;
     }
 
-    /**
-     * @param PackageManagerPackageInterface $package
-     * @return string
-     */
     protected function createPackageLine(PackageManagerPackageInterface $package): string
     {
         $line = "## {$package->getName()} `{$package->getVersion()}`";
@@ -116,27 +98,16 @@ class MarkdownWriter implements WriterInterface
         return $line;
     }
 
-    /**
-     * @param null|string $description
-     * @return string
-     */
     protected function createDescriptionLine(?string $description): string
     {
         return "> $description";
     }
 
-    /**
-     * @param PackageManagerPackageInterface $package
-     * @return string
-     */
     protected function createExternalLink(PackageManagerPackageInterface $package): string
     {
         return "[link]({$package->getExternalLink()})";
     }
 
-    /**
-     * @return WriterConfiguration
-     */
     public function getConfiguration(): WriterConfiguration
     {
         return $this->configuration;

--- a/tests/Application/ApplicationBuilderTest.php
+++ b/tests/Application/ApplicationBuilderTest.php
@@ -6,12 +6,15 @@ namespace DepDocTest\Application;
 
 use DepDoc\Application\ApplicationBuilder;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class ApplicationBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItBuildsApplication(): void
     {
         $containerBuilder = $this->prophesize(ContainerBuilder::class);

--- a/tests/Application/ApplicationBuilderTest.php
+++ b/tests/Application/ApplicationBuilderTest.php
@@ -33,7 +33,7 @@ class ApplicationBuilderTest extends TestCase
 
         $containerBuilderValue = $reflContainerProperty->getValue($application);
 
-        $this->assertEquals($containerBuilder->reveal(), $containerBuilderValue);
+        self::assertEquals($containerBuilder->reveal(), $containerBuilderValue);
     }
 
     public function testItUsesDefaultDependencies(): void
@@ -47,13 +47,13 @@ class ApplicationBuilderTest extends TestCase
         $reflLoaderProp = $reflBuilder->getProperty('loader');
         $reflLoaderProp->setAccessible(true);
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             ContainerBuilder::class,
             $reflContainerBuilderProp->getValue($builder),
             'default container builder should be instance of ' . ContainerBuilder::class
         );
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             YamlFileLoader::class,
             $reflLoaderProp->getValue($builder),
             'default loader should be instance of ' . YamlFileLoader::class

--- a/tests/Application/DepDocApplicationTest.php
+++ b/tests/Application/DepDocApplicationTest.php
@@ -7,12 +7,15 @@ use DepDoc\Command\UpdateCommand;
 use DepDoc\Command\ValidateCommand;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputDefinition;
 
 class DepDocApplicationTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItShouldHaveExpectedCommands()
     {
         $validateCommand = $this->prophesize(ValidateCommand::class);

--- a/tests/Application/DepDocApplicationTest.php
+++ b/tests/Application/DepDocApplicationTest.php
@@ -38,8 +38,8 @@ class DepDocApplicationTest extends TestCase
 
         $application = new DepDocApplication($container->reveal());
 
-        $this->assertEquals('DepDoc', $application->getName());
-        $this->assertTrue($application->has('update'));
-        $this->assertTrue($application->has('validate'));
+        self::assertEquals('DepDoc', $application->getName());
+        self::assertTrue($application->has('update'));
+        self::assertTrue($application->has('validate'));
     }
 }

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -11,6 +11,7 @@ use DepDoc\PackageManager\PackageList\PackageManagerPackageList;
 use phpmock\prophecy\PHPProphet;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,12 +19,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BaseCommandTest extends TestCase
 {
-    /** @var PHPProphet */
-    protected $prophet;
+    use ProphecyTrait;
+
+    protected PHPProphet $globalProphet;
 
     protected function setUp(): void
     {
-        $this->prophet = new PHPProphet();
+        $this->globalProphet = new PHPProphet();
     }
 
     public function testItConfiguresDirectoryOption()
@@ -51,14 +53,14 @@ class BaseCommandTest extends TestCase
 
     public function testItValidatesInputDirectoryCorrectly()
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Command');
 
         $input = $this->prophesize(InputInterface::class);
         $output = $this->prophesize(OutputInterface::class);
 
         $input->getOption('directory')->willReturn('/test/dir')->shouldBeCalled();
 
-        $prophecy->realpath('/test/dir')->willReturn(true)->shouldBeCalled();
+        $globalProphecy->realpath('/test/dir')->willReturn(true)->shouldBeCalled();
 
         $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL)->shouldBeCalled();
         $output->isVerbose()->willReturn(false)->shouldBeCalled();
@@ -67,7 +69,7 @@ class BaseCommandTest extends TestCase
             ->willReturn($this->prophesize(OutputFormatterInterface::class)->reveal())
             ->shouldBeCalled();
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
 
         $helperSet = $this->prophesize(HelperSet::class);
 
@@ -83,12 +85,12 @@ class BaseCommandTest extends TestCase
 
         $this->assertEquals(0, $result);
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testItVerboseOutputsTargetDirectory()
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
+        $prophecy = $this->globalProphet->prophesize('DepDoc\\Command');
 
         $input = $this->prophesize(InputInterface::class);
         $output = $this->prophesize(OutputInterface::class);
@@ -122,7 +124,7 @@ class BaseCommandTest extends TestCase
 
         $this->assertEquals(0, $result);
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testItStopsOnEmptyDirectoryOption()
@@ -160,14 +162,14 @@ class BaseCommandTest extends TestCase
 
     public function testItStopsOnInvalidDirectoryOption()
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Command');
 
         $input = $this->prophesize(InputInterface::class);
         $output = $this->prophesize(OutputInterface::class);
 
         $input->getOption('directory')->willReturn('/test/dir')->shouldBeCalled();
 
-        $prophecy->realpath('/test/dir')->willReturn(false)->shouldBeCalled();
+        $globalProphecy->realpath('/test/dir')->willReturn(false)->shouldBeCalled();
 
         $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL)->shouldBeCalled();
         $output->isDecorated()->willReturn(false)->shouldBeCalled();
@@ -179,7 +181,7 @@ class BaseCommandTest extends TestCase
         $output->writeln(Argument::containingString('<fg=white;bg=red> [ERROR] Invalid target directory given: '),
             1)->shouldBeCalled();
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
 
         $helperSet = $this->prophesize(HelperSet::class);
 

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -42,13 +42,13 @@ class BaseCommandTest extends TestCase
         $command->setHelperSet($helperSet->reveal());
 
         $definition = $command->getDefinition();
-        $this->assertTrue($definition->hasOption('directory'));
+        self::assertTrue($definition->hasOption('directory'));
 
         $option = $definition->getOption('directory');
-        $this->assertEquals('directory', $option->getName());
-        $this->assertEquals('d', $option->getShortcut());
-        $this->assertTrue($option->isValueRequired());
-        $this->assertEquals(getcwd(), $option->getDefault());
+        self::assertEquals('directory', $option->getName());
+        self::assertEquals('d', $option->getShortcut());
+        self::assertTrue($option->isValueRequired());
+        self::assertEquals(getcwd(), $option->getDefault());
     }
 
     public function testItValidatesInputDirectoryCorrectly()
@@ -83,7 +83,7 @@ class BaseCommandTest extends TestCase
         $command->setHelperSet($helperSet->reveal());
         $result = $command->runExecute($input->reveal(), $output->reveal());
 
-        $this->assertEquals(0, $result);
+        self::assertEquals(0, $result);
 
         $this->globalProphet->checkPredictions();
     }
@@ -122,7 +122,7 @@ class BaseCommandTest extends TestCase
 
         $result = $command->runExecute($input->reveal(), $output->reveal());
 
-        $this->assertEquals(0, $result);
+        self::assertEquals(0, $result);
 
         $this->globalProphet->checkPredictions();
     }
@@ -157,7 +157,7 @@ class BaseCommandTest extends TestCase
 
         $result = $command->runExecute($input->reveal(), $output->reveal());
 
-        $this->assertEquals(-1, $result);
+        self::assertEquals(-1, $result);
     }
 
     public function testItStopsOnInvalidDirectoryOption()
@@ -196,7 +196,7 @@ class BaseCommandTest extends TestCase
 
         $result = $command->runExecute($input->reveal(), $output->reveal());
 
-        $this->assertEquals(-1, $result);
+        self::assertEquals(-1, $result);
     }
 
     public function testItCombinesAllInstalledPackages()
@@ -238,13 +238,13 @@ class BaseCommandTest extends TestCase
         );
 
         $packages = $command->testGetInstalledPackages($targetDirectory);
-        $this->assertTrue($packages->has('Composer', 't1'));
-        $this->assertTrue($packages->has('Composer', 't2'));
-        $this->assertTrue($packages->has('Composer', 't3'));
-        $this->assertTrue($packages->has('Node', 't1'));
-        $this->assertTrue($packages->has('Node', 't2'));
-        $this->assertTrue($packages->has('Node', 't3'));
-        $this->assertCount(6, $packages->getAllFlat());
+        self::assertTrue($packages->has('Composer', 't1'));
+        self::assertTrue($packages->has('Composer', 't2'));
+        self::assertTrue($packages->has('Composer', 't3'));
+        self::assertTrue($packages->has('Node', 't1'));
+        self::assertTrue($packages->has('Node', 't2'));
+        self::assertTrue($packages->has('Node', 't3'));
+        self::assertCount(6, $packages->getAllFlat());
     }
 
     /**

--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -21,7 +21,7 @@ class BaseCommandTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }

--- a/tests/Command/UpdateCommandTest.php
+++ b/tests/Command/UpdateCommandTest.php
@@ -30,12 +30,12 @@ class UpdateCommandTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         MockRegistry::getInstance()->unregisterAll();
     }

--- a/tests/Command/UpdateCommandTest.php
+++ b/tests/Command/UpdateCommandTest.php
@@ -20,6 +20,7 @@ use phpmock\MockRegistry;
 use phpmock\prophecy\PHPProphet;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,12 +28,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateCommandTest extends TestCase
 {
-    /** @var PHPProphet */
-    protected $prophet;
+    use ProphecyTrait;
+
+    protected PHPProphet $globalProphet;
 
     protected function setUp(): void
     {
-        $this->prophet = new PHPProphet();
+        $this->globalProphet = new PHPProphet();
     }
 
     protected function tearDown(): void
@@ -150,24 +152,24 @@ class UpdateCommandTest extends TestCase
 
         $input->getOption('directory')->willReturn('/test');
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Command');
+        $globalProphecy
             ->file_exists(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
-        $prophecy
+        $globalProphecy
             ->realpath(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
 
         $this->assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal())
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testReturnsErrorsWhenValidationOfLockedVersionsFails(): void
@@ -231,24 +233,24 @@ class UpdateCommandTest extends TestCase
 
         $input->getOption('directory')->willReturn('/test');
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Command');
+        $globalProphecy
             ->file_exists(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
-        $prophecy
+        $globalProphecy
             ->realpath(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
 
         $this->assertEquals(
             1,
             $command->run($input->reveal(), $output->reveal())
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     /**

--- a/tests/Command/UpdateCommandTest.php
+++ b/tests/Command/UpdateCommandTest.php
@@ -53,7 +53,7 @@ class UpdateCommandTest extends TestCase
             $this->prophesize(ConfigurationService::class)->reveal()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'Update or create a DEPENDENCIES.md',
             $command->getDescription(),
             'description should be as expected'
@@ -83,7 +83,7 @@ class UpdateCommandTest extends TestCase
 
         $input->getOption('directory')->willReturn('')->shouldBeCalledOnce();
 
-        $this->assertEquals(
+        self::assertEquals(
             -1,
             $command->run($input->reveal(), $output->reveal())
         );
@@ -164,7 +164,7 @@ class UpdateCommandTest extends TestCase
 
         $globalProphecy->reveal();
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal())
         );
@@ -245,7 +245,7 @@ class UpdateCommandTest extends TestCase
 
         $globalProphecy->reveal();
 
-        $this->assertEquals(
+        self::assertEquals(
             1,
             $command->run($input->reveal(), $output->reveal())
         );

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -17,6 +17,7 @@ use phpmock\MockRegistry;
 use phpmock\prophecy\PHPProphet;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,12 +25,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ValidateCommandTest extends TestCase
 {
-    /** @var PHPProphet */
-    protected $prophet;
+    use ProphecyTrait;
+
+    protected PHPProphet $globalProphet;
 
     protected function setUp(): void
     {
-        $this->prophet = new PHPProphet();
+        $this->globalProphet = new PHPProphet();
     }
 
     protected function tearDown(): void
@@ -142,7 +144,7 @@ class ValidateCommandTest extends TestCase
             $command->run($input->reveal(), $output->reveal())
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testItDeterminesVeryStrictMode(): void
@@ -187,7 +189,7 @@ class ValidateCommandTest extends TestCase
             'exit code should match'
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testItDeterminesStrictMode(): void
@@ -233,7 +235,7 @@ class ValidateCommandTest extends TestCase
             'exit code should match'
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     public function testItDeterminesDefaultStrictMode(): void
@@ -279,7 +281,7 @@ class ValidateCommandTest extends TestCase
             'exit code should match'
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     /**
@@ -370,16 +372,16 @@ class ValidateCommandTest extends TestCase
 
     protected function prophesizeSystemCalls(): void
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\Command');
-        $prophecy
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Command');
+        $globalProphecy
             ->file_exists(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
-        $prophecy
+        $globalProphecy
             ->realpath(Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
     }
 }

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -49,7 +49,7 @@ class ValidateCommandTest extends TestCase
             $this->prophesize(ConfigurationService::class)->reveal()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'Validate an already generated DEPENDENCIES.md',
             $command->getDescription(),
             'description should be as expected'
@@ -78,7 +78,7 @@ class ValidateCommandTest extends TestCase
 
         $input->getOption('directory')->willReturn('')->shouldBeCalledOnce();
 
-        $this->assertEquals(
+        self::assertEquals(
             -1,
             $command->run($input->reveal(), $output->reveal())
         );
@@ -139,7 +139,7 @@ class ValidateCommandTest extends TestCase
 
         $this->prophesizeSystemCalls();
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal())
         );
@@ -183,7 +183,7 @@ class ValidateCommandTest extends TestCase
 
         $this->prophesizeSystemCalls();
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal()),
             'exit code should match'
@@ -229,7 +229,7 @@ class ValidateCommandTest extends TestCase
 
         $this->prophesizeSystemCalls();
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal()),
             'exit code should match'
@@ -275,7 +275,7 @@ class ValidateCommandTest extends TestCase
 
         $this->prophesizeSystemCalls();
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
             $command->run($input->reveal(), $output->reveal()),
             'exit code should match'

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -27,12 +27,12 @@ class ValidateCommandTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         MockRegistry::getInstance()->unregisterAll();
     }

--- a/tests/Dependencies/DependencyDataTest.php
+++ b/tests/Dependencies/DependencyDataTest.php
@@ -5,9 +5,12 @@ namespace DepDocTest\Dependencies;
 use DepDoc\Dependencies\DependencyData;
 use DepDoc\Dependencies\DependencyDataAdditionalContent;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DependencyDataTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItTakesConstructorDefaultValues()
     {
         $dependency = new DependencyData('manager', 'name', 'version', null);

--- a/tests/Dependencies/DependencyDataTest.php
+++ b/tests/Dependencies/DependencyDataTest.php
@@ -14,23 +14,23 @@ class DependencyDataTest extends TestCase
     public function testItTakesConstructorDefaultValues()
     {
         $dependency = new DependencyData('manager', 'name', 'version', null);
-        $this->assertNull($dependency->getLockSymbol());
-        $this->assertInstanceOf(DependencyDataAdditionalContent::class, $dependency->getAdditionalContent());
-        $this->assertEquals([], $dependency->getAdditionalContent()->getAll());
+        self::assertNull($dependency->getLockSymbol());
+        self::assertInstanceOf(DependencyDataAdditionalContent::class, $dependency->getAdditionalContent());
+        self::assertEquals([], $dependency->getAdditionalContent()->getAll());
     }
 
     public function testItStoresAdditionContent()
     {
         $dependency = new DependencyData('manager', 'name', 'version', null, [1, 2, 3]);
-        $this->assertEquals([1, 2, 3], $dependency->getAdditionalContent()->getAll());
+        self::assertEquals([1, 2, 3], $dependency->getAdditionalContent()->getAll());
     }
 
     public function testItKnowsItLockedIfLockSymbolProvided()
     {
         $dependency = new DependencyData('manager', 'name', 'version', 'symbol');
-        $this->assertTrue($dependency->isVersionLocked());
+        self::assertTrue($dependency->isVersionLocked());
 
         $dependency = new DependencyData('manager', 'name', 'version', null);
-        $this->assertFalse($dependency->isVersionLocked());
+        self::assertFalse($dependency->isVersionLocked());
     }
 }

--- a/tests/PackageManager/ComposerPackageManagerTest.php
+++ b/tests/PackageManager/ComposerPackageManagerTest.php
@@ -13,9 +13,12 @@ use Composer\Semver\Constraint\ConstraintInterface;
 use DepDoc\PackageManager\ComposerPackageManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ComposerPackageManagerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testGetInstalledPackages()
     {
         $package = $this->prophesize(CompletePackage::class);

--- a/tests/PackageManager/ComposerPackageManagerTest.php
+++ b/tests/PackageManager/ComposerPackageManagerTest.php
@@ -78,7 +78,7 @@ class ComposerPackageManagerTest extends TestCase
 
         $installedPackages = $composerPackageManager->getInstalledPackages('');
 
-        $this->assertTrue(
+        self::assertTrue(
             $installedPackages->has(
                 $composerPackageManager->getName(), 'test/test'
             ),
@@ -169,13 +169,13 @@ class ComposerPackageManagerTest extends TestCase
             $composerPackageManager->getName()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'abc/abc',
             array_shift($composerPackages)->getName(),
             'first package should be abc package'
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'test/test',
             array_shift($composerPackages)->getName(),
             'second package should be test package'
@@ -229,7 +229,7 @@ class ComposerPackageManagerTest extends TestCase
 
         $installedPackages = $composerPackageManager->getInstalledPackages('');
 
-        $this->assertFalse(
+        self::assertFalse(
             $installedPackages->has(
                 $composerPackageManager->getName(), 'test/test'
             ),

--- a/tests/PackageManager/Factory/ComposerPackageManagerFactoryTest.php
+++ b/tests/PackageManager/Factory/ComposerPackageManagerFactoryTest.php
@@ -10,12 +10,15 @@ use Composer\IO\NullIO;
 use DepDoc\PackageManager\Factory\ComposerPackageManagerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @package DepDocTest\PackageManager\Factory
  */
 class ComposerPackageManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItBuildsComposerPackageManager(): void
     {
         $composerFactory = $this->prophesize(Factory::class);

--- a/tests/PackageManager/NodePackageManagerTest.php
+++ b/tests/PackageManager/NodePackageManagerTest.php
@@ -7,15 +7,17 @@ use DepDoc\PackageManager\Package\NodePackage;
 use phpmock\Mock;
 use phpmock\prophecy\PHPProphet;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NodePackageManagerTest extends TestCase
 {
-    /** @var PHPProphet */
-    protected $prophet;
+    use ProphecyTrait;
+
+    protected PHPProphet $globalProphet;
 
     protected function setUp(): void
     {
-        $this->prophet = new PHPProphet();
+        $this->globalProphet = new PHPProphet();
     }
 
     protected function tearDown(): void
@@ -27,11 +29,11 @@ class NodePackageManagerTest extends TestCase
 
     public function testGetInstalledPackages()
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\PackageManager');
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\PackageManager');
 
         $targetDirectory = '/some/dir';
         $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
-        $prophecy
+        $globalProphecy
             ->shell_exec($command)
             ->shouldBeCalledTimes(1)
             ->willReturn(<<<JSON
@@ -62,7 +64,7 @@ class NodePackageManagerTest extends TestCase
 JSON
             );
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
         $manager = new NodePackageManager();
 
         $packages = $manager->getInstalledPackages($targetDirectory);
@@ -79,16 +81,16 @@ JSON
 
     public function testOutputWithNullReturnsEmptyPackageList()
     {
-        $prophecy = $this->prophet->prophesize('DepDoc\\PackageManager');
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\PackageManager');
 
         $targetDirectory = '/some/dir';
         $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
-        $prophecy
+        $globalProphecy
             ->shell_exec($command)
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
         $manager = new NodePackageManager();
 
         $packages = $manager->getInstalledPackages($targetDirectory);

--- a/tests/PackageManager/NodePackageManagerTest.php
+++ b/tests/PackageManager/NodePackageManagerTest.php
@@ -27,7 +27,7 @@ class NodePackageManagerTest extends TestCase
         Mock::disableAll();
     }
 
-    public function testGetInstalledPackages()
+    public function testGetInstalledPackages(): void
     {
         $globalProphecy = $this->globalProphet->prophesize('DepDoc\\PackageManager');
 
@@ -68,18 +68,18 @@ JSON
         $manager = new NodePackageManager();
 
         $packages = $manager->getInstalledPackages($targetDirectory);
-        $this->assertCount(1, $packages->getAllFlat());
-        $this->assertTrue($packages->has($manager->getName(), 'Test'));
+        self::assertCount(1, $packages->getAllFlat());
+        self::assertTrue($packages->has($manager->getName(), 'Test'));
 
         /** @var NodePackage $package */
         $package = $packages->get($manager->getName(), 'Test');
-        $this->assertInstanceOf(NodePackage::class, $package);
-        $this->assertEquals('Test', $package->getName());
-        $this->assertEquals('1.0.0', $package->getVersion());
-        $this->assertEquals('awesome package', $package->getDescription());
+        self::assertInstanceOf(NodePackage::class, $package);
+        self::assertEquals('Test', $package->getName());
+        self::assertEquals('1.0.0', $package->getVersion());
+        self::assertEquals('awesome package', $package->getDescription());
     }
 
-    public function testOutputWithNullReturnsEmptyPackageList()
+    public function testOutputWithNullReturnsEmptyPackageList(): void
     {
         $globalProphecy = $this->globalProphet->prophesize('DepDoc\\PackageManager');
 
@@ -94,6 +94,6 @@ JSON
         $manager = new NodePackageManager();
 
         $packages = $manager->getInstalledPackages($targetDirectory);
-        $this->assertCount(0, $packages->getAllFlat(), 'there should be no packages');
+        self::assertCount(0, $packages->getAllFlat(), 'there should be no packages');
     }
 }

--- a/tests/PackageManager/NodePackageManagerTest.php
+++ b/tests/PackageManager/NodePackageManagerTest.php
@@ -31,7 +31,6 @@ class NodePackageManagerTest extends TestCase
 
         $targetDirectory = '/some/dir';
         $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
-        $commandOutput = null;
         $prophecy
             ->shell_exec($command)
             ->shouldBeCalledTimes(1)
@@ -42,6 +41,21 @@ class NodePackageManagerTest extends TestCase
       "name": "Test",
       "version": "1.0.0",
       "description": "awesome package"
+    },
+    "SomeExtraneous": {
+      "name": "Extraneous package",
+      "version": "1.0.0",
+      "extraneous": true
+    },
+    "svelte": {
+      "name": "svelte",
+      "version": "*",
+      "peerMissing": [
+        {
+          "requiredBy": "@storybook/addon-storyshots@6.2.9",
+          "requires": "svelte@*"
+        }
+      ]
     }
   }
 }
@@ -68,8 +82,7 @@ JSON
         $prophecy = $this->prophet->prophesize('DepDoc\\PackageManager');
 
         $targetDirectory = '/some/dir';
-        $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list -json -depth 0 -long';
-        $commandOutput = null;
+        $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
         $prophecy
             ->shell_exec($command)
             ->shouldBeCalledTimes(1)

--- a/tests/PackageManager/NodePackageManagerTest.php
+++ b/tests/PackageManager/NodePackageManagerTest.php
@@ -13,12 +13,12 @@ class NodePackageManagerTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -30,7 +30,7 @@ class NodePackageManagerTest extends TestCase
         $prophecy = $this->prophet->prophesize('DepDoc\\PackageManager');
 
         $targetDirectory = '/some/dir';
-        $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list -json -depth 0 -long';
+        $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
         $commandOutput = null;
         $prophecy
             ->shell_exec($command)

--- a/tests/PackageManager/Package/ComposerPackageTest.php
+++ b/tests/PackageManager/Package/ComposerPackageTest.php
@@ -13,13 +13,13 @@ class ComposerPackageTest extends TestCase
     public function testItBuildsCorrectExternalLInk()
     {
         $package = new ComposerPackage('Composer', 'test/package', '1.0.0', null);
-        $this->assertEquals('https://packagist.org/packages/test/package', $package->getExternalLink());
+        self::assertEquals('https://packagist.org/packages/test/package', $package->getExternalLink());
     }
 
     public function testItReturnsAnInformativeString()
     {
         $package = new ComposerPackage('Composer', 'test/package', '1.0.0', null);
-        $this->assertEquals(
+        self::assertEquals(
             '[Composer] test/package (1.0.0 / https://packagist.org/packages/test/package)',
             $package->__toString()
         );

--- a/tests/PackageManager/Package/ComposerPackageTest.php
+++ b/tests/PackageManager/Package/ComposerPackageTest.php
@@ -4,9 +4,12 @@ namespace DepDocTest\PackageManager\Package;
 
 use DepDoc\PackageManager\Package\ComposerPackage;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ComposerPackageTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItBuildsCorrectExternalLInk()
     {
         $package = new ComposerPackage('Composer', 'test/package', '1.0.0', null);

--- a/tests/PackageManager/Package/NodePackageTest.php
+++ b/tests/PackageManager/Package/NodePackageTest.php
@@ -13,13 +13,13 @@ class NodePackageTest extends TestCase
     public function testItBuildsCorrectExternalLInk()
     {
         $package = new NodePackage('Node', 'test/package', '1.0.0', null);
-        $this->assertEquals('https://www.npmjs.com/package/test/package', $package->getExternalLink());
+        self::assertEquals('https://www.npmjs.com/package/test/package', $package->getExternalLink());
     }
 
     public function testItReturnsAnInformativeString()
     {
         $package = new NodePackage('Node', 'test/package', '1.0.0', null);
-        $this->assertEquals(
+        self::assertEquals(
             '[Node] test/package (1.0.0 / https://www.npmjs.com/package/test/package)',
             $package->__toString()
         );

--- a/tests/PackageManager/Package/NodePackageTest.php
+++ b/tests/PackageManager/Package/NodePackageTest.php
@@ -4,9 +4,12 @@ namespace DepDocTest\PackageManager\Package;
 
 use DepDoc\PackageManager\Package\NodePackage;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NodePackageTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItBuildsCorrectExternalLInk()
     {
         $package = new NodePackage('Node', 'test/package', '1.0.0', null);

--- a/tests/PackageManager/Package/PackageManagerPackageTest.php
+++ b/tests/PackageManager/Package/PackageManagerPackageTest.php
@@ -5,9 +5,11 @@ namespace DepDocTest\PackageManager\Package;
 use DepDoc\PackageManager\Package\PackageManagerPackage;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PackageManagerPackageTest extends TestCase
 {
+    use ProphecyTrait;
 
     public function testToStringThrowsException()
     {

--- a/tests/PackageManager/Package/PackageManagerPackageTest.php
+++ b/tests/PackageManager/Package/PackageManagerPackageTest.php
@@ -14,6 +14,6 @@ class PackageManagerPackageTest extends TestCase
     public function testToStringThrowsException()
     {
         $package = new PackageManagerPackage('Test', 'test/package', '1.0.0');
-        $this->assertEquals('[Test] test/package (1.0.0)', $package->__toString());
+        self::assertEquals('[Test] test/package (1.0.0)', $package->__toString());
     }
 }

--- a/tests/PackageManager/PackageList/PackageManagerPackageListTest.php
+++ b/tests/PackageManager/PackageList/PackageManagerPackageListTest.php
@@ -4,9 +4,12 @@ namespace DepDocTest\PackageManager\PackageList;
 
 use DepDoc\PackageManager\Package\PackageManagerPackageInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PackageManagerPackageListTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItAddsPackage()
     {
         $package = $this->prophesize(PackageManagerPackageInterface::class);

--- a/tests/PackageManager/PackageList/PackageManagerPackageListTest.php
+++ b/tests/PackageManager/PackageList/PackageManagerPackageListTest.php
@@ -2,7 +2,7 @@
 
 namespace DepDocTest\PackageManager\PackageList;
 
-use DepDoc\PackageManager\Package\PackageManagerPackageInterface;
+use DepDoc\PackageManager\Package\PackageManagerPackage;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -10,126 +10,102 @@ class PackageManagerPackageListTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testItAddsPackage()
+    public function testItAddsPackage(): void
     {
-        $package = $this->prophesize(PackageManagerPackageInterface::class);
-        $package->getManagerName()->willReturn('Composer');
-        $package->getName()->willReturn('test');
+        $package = new PackageManagerPackage('Composer', 'test', '1');
 
         $list = new PackageManagerPackageListTestDouble();
 
         // Will create an empty array for cached dependencies
-        $this->assertNull($list->getCachedFlatDependencies());
+        self::assertNull($list->getCachedFlatDependencies());
         $list->getAllFlat();
-        $this->assertNotNull($list->getCachedFlatDependencies());
+        self::assertNotNull($list->getCachedFlatDependencies());
 
-        $list->add($package->reveal());
-        $this->assertNull($list->getCachedFlatDependencies());
-        $this->assertEquals(['Composer' => ['test' => $package->reveal()]], $list->getDependencies());
+        $list->add($package);
+        self::assertNull($list->getCachedFlatDependencies());
+        self::assertEquals(['Composer' => ['test' => $package]], $list->getDependencies());
     }
 
-    public function testHas()
+    public function testHas(): void
     {
-        $package = $this->prophesize(PackageManagerPackageInterface::class);
-        $package->getManagerName()->willReturn('Composer');
-        $package->getName()->willReturn('test');
+        $package = new PackageManagerPackage('Composer', 'test', '1');
 
         $list = new PackageManagerPackageListTestDouble();
-        $this->assertFalse($list->has('Composer', 'test'));
+        self::assertFalse($list->has('Composer', 'test'));
 
-        $list->add($package->reveal());
-        $this->assertTrue($list->has('Composer', 'test'));
+        $list->add($package);
+        self::assertTrue($list->has('Composer', 'test'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
-        $package = $this->prophesize(PackageManagerPackageInterface::class);
-        $package->getManagerName()->willReturn('Composer');
-        $package->getName()->willReturn('test');
+        $package = new PackageManagerPackage('Composer', 'test', '1');
 
         $list = new PackageManagerPackageListTestDouble();
-        $this->assertNull($list->get('Composer', 'test'));
+        self::assertNull($list->get('Composer', 'test'));
 
-        $list->add($package->reveal());
-        $this->assertEquals($package->reveal(), $list->get('Composer', 'test'));
+        $list->add($package);
+        self::assertEquals($package, $list->get('Composer', 'test'));
     }
 
-    public function testGetAllReturnsMultiLevelArray()
+    public function testGetAllReturnsMultiLevelArray(): void
     {
-        $package1 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package1->getManagerName()->willReturn('Composer');
-        $package1->getName()->willReturn('test1');
-        $package2 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package2->getManagerName()->willReturn('Node');
-        $package2->getName()->willReturn('test2');
+        $package1 = new PackageManagerPackage('Composer', 'test1', '1');
+        $package2 = new PackageManagerPackage('Node', 'test2', '1');
 
         $list = new PackageManagerPackageListTestDouble();
-        $this->assertEmpty($list->getAll());
+        self::assertEmpty($list->getAll());
 
-        $list->add($package1->reveal());
-        $list->add($package2->reveal());
-        $this->assertEquals([
-            'Composer' => ['test1' => $package1->reveal()],
-            'Node' => ['test2' => $package2->reveal()],
+        $list->add($package1);
+        $list->add($package2);
+        self::assertEquals([
+            'Composer' => ['test1' => $package1],
+            'Node' => ['test2' => $package2],
         ], $list->getAll());
     }
 
-    public function testGetAllFlatReturnsFlatArray()
+    public function testGetAllFlatReturnsFlatArray(): void
     {
-        $package1 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package1->getManagerName()->willReturn('Composer');
-        $package1->getName()->willReturn('test1');
-        $package2 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package2->getManagerName()->willReturn('Composer');
-        $package2->getName()->willReturn('test2');
-        $package3 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package3->getManagerName()->willReturn('Node');
-        $package3->getName()->willReturn('test3');
-        $package4 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package4->getManagerName()->willReturn('Node');
-        $package4->getName()->willReturn('test2');
-        $package5 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package5->getManagerName()->willReturn('Node');
-        $package5->getName()->willReturn('test3');
+        $package1 = new PackageManagerPackage('Composer', 'test1', '1');
+        $package2 = new PackageManagerPackage('Composer', 'test2', '1');
+        $package3 = new PackageManagerPackage('Node', 'test3', '1');
+        $package4 = new PackageManagerPackage('Node', 'test2', '1');
+        $package5 = new PackageManagerPackage('Node', 'test3', '1');
 
         $list = new PackageManagerPackageListTestDouble();
-        $this->assertEmpty($list->getAll());
+        self::assertEmpty($list->getAll());
 
-        $list->add($package1->reveal());
-        $list->add($package2->reveal());
-        $list->add($package3->reveal());
-        $list->add($package4->reveal());
-        $list->add($package5->reveal());
-        $this->assertEquals([
-            $package1->reveal(),
-            $package2->reveal(),
-            $package5->reveal(),
-            $package4->reveal(),
+        $list->add($package1);
+        $list->add($package2);
+        $list->add($package3);
+        $list->add($package4);
+        $list->add($package5);
+        self::assertEquals([
+            $package1,
+            $package2,
+            $package5,
+            $package4,
         ], $list->getAllFlat());
     }
 
-    public function testGetAllByManager()
+    public function testGetAllByManager(): void
     {
-        $package1 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package1->getManagerName()->willReturn('Composer');
-        $package1->getName()->willReturn('test1');
-        $package2 = $this->prophesize(PackageManagerPackageInterface::class);
-        $package2->getManagerName()->willReturn('Node');
-        $package2->getName()->willReturn('test2');
+        $package1 = new PackageManagerPackage('Composer', 'test1', '1');
+        $package2 = new PackageManagerPackage('Node', 'test2', '1');
 
         $list = new PackageManagerPackageListTestDouble();
-        $this->assertEmpty($list->getAllByManager('Composer'));
-        $this->assertEmpty($list->getAllByManager('Node'));
+        self::assertEmpty($list->getAllByManager('Composer'));
+        self::assertEmpty($list->getAllByManager('Node'));
 
-        $list->add($package1->reveal());
-        $this->assertEquals([
-            'test1' => $package1->reveal()
+        $list->add($package1);
+        self::assertEquals([
+            'test1' => $package1
         ], $list->getAllByManager('Composer'));
-        $this->assertEmpty($list->getAllByManager('Node'));
+        self::assertEmpty($list->getAllByManager('Node'));
 
-        $list->add($package2->reveal());
-        $this->assertEquals([
-            'test2' => $package2->reveal()
+        $list->add($package2);
+        self::assertEquals([
+            'test2' => $package2
         ], $list->getAllByManager('Node'));
     }
 }

--- a/tests/PackageManager/PackageList/PackageManagerPackageListTestDouble.php
+++ b/tests/PackageManager/PackageList/PackageManagerPackageListTestDouble.php
@@ -9,7 +9,7 @@ use DepDoc\PackageManager\PackageList\PackageManagerPackageList;
 class PackageManagerPackageListTestDouble extends PackageManagerPackageList
 {
     /**
-     * @return \DepDoc\PackageManager\Package\PackageManagerPackage[][]
+     * @return PackageManagerPackage[][]
      */
     public function getDependencies(): array
     {

--- a/tests/Parser/MarkdownParserTest.php
+++ b/tests/Parser/MarkdownParserTest.php
@@ -14,12 +14,12 @@ class MarkdownParserTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Parser/MarkdownParserTest.php
+++ b/tests/Parser/MarkdownParserTest.php
@@ -46,23 +46,23 @@ class MarkdownParserTest extends TestCase
         $packageList = $parser->getDocumentedDependencies($filepath, null);
 
         $packages = $packageList->getAllFlat();
-        $this->assertCount(8, $packages);
+        self::assertCount(8, $packages);
 
         /** @var DependencyData $package */
         $package = $packageList->get('Composer', 'php-mock/php-mock-prophecy');
-        $this->assertNotNull($package);
-        $this->assertCount(2, $package->getAdditionalContent()->getAll());
-        $this->assertEquals(['', 'working'], array_values($package->getAdditionalContent()->getAll()));
+        self::assertNotNull($package);
+        self::assertCount(2, $package->getAdditionalContent()->getAll());
+        self::assertEquals(['', 'working'], array_values($package->getAdditionalContent()->getAll()));
 
         $package = $packageList->get('Composer', 'symfony/console');
-        $this->assertNotNull($package);
-        $this->assertCount(3, $package->getAdditionalContent()->getAll());
-        $this->assertEquals(['', 'test 1  ', 'test 2'], array_values($package->getAdditionalContent()->getAll()));
+        self::assertNotNull($package);
+        self::assertCount(3, $package->getAdditionalContent()->getAll());
+        self::assertEquals(['', 'test 1  ', 'test 2'], array_values($package->getAdditionalContent()->getAll()));
 
         $package = $packageList->get('Composer', 'symfony/yaml');
-        $this->assertNotNull($package);
-        $this->assertCount(4, $package->getAdditionalContent()->getAll());
-        $this->assertEquals(['', 'Will leave only one', '', 'consecutive empty line'], array_values($package->getAdditionalContent()->getAll()));
+        self::assertNotNull($package);
+        self::assertCount(4, $package->getAdditionalContent()->getAll());
+        self::assertEquals(['', 'Will leave only one', '', 'consecutive empty line'], array_values($package->getAdditionalContent()->getAll()));
     }
 
     public function getValidDependenciesFileData(): string

--- a/tests/Validator/PackageValidatorTest.php
+++ b/tests/Validator/PackageValidatorTest.php
@@ -11,9 +11,12 @@ use DepDoc\Validator\Result\ErrorMissingDocumentationResult;
 use DepDoc\Validator\Result\ErrorVersionMismatchResult;
 use DepDoc\Validator\StrictMode;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PackageValidatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testItComparesForLockedOnly()
     {
         $installedPackages = $this->prophesize(PackageManagerPackageList::class);

--- a/tests/Validator/PackageValidatorTest.php
+++ b/tests/Validator/PackageValidatorTest.php
@@ -48,12 +48,12 @@ class PackageValidatorTest extends TestCase
             $dependencyList->reveal()
         );
 
-        $this->assertCount(1, $errorResultList);
+        self::assertCount(1, $errorResultList);
         foreach ($errorResultList as $errorResult) {
             if ($errorResult instanceof ErrorVersionMismatchResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test2');
+                self::assertEquals($errorResult->getPackageName(), 'test2');
             } else {
-                $this->fail('Unexpected error result: ' . get_class($errorResult));
+                self::fail('Unexpected error result: ' . get_class($errorResult));
             }
         }
     }
@@ -97,16 +97,16 @@ class PackageValidatorTest extends TestCase
             $dependencyList->reveal()
         );
 
-        $this->assertCount(3, $errorResultList);
+        self::assertCount(3, $errorResultList);
         foreach ($errorResultList as $errorResult) {
             if ($errorResult instanceof ErrorMissingDocumentationResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test1');
+                self::assertEquals($errorResult->getPackageName(), 'test1');
             } elseif ($errorResult instanceof ErrorVersionMismatchResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test2');
+                self::assertEquals($errorResult->getPackageName(), 'test2');
             } elseif ($errorResult instanceof ErrorDocumentedButNotInstalledResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test3');
+                self::assertEquals($errorResult->getPackageName(), 'test3');
             } else {
-                $this->fail('Unexpected error result: ' . get_class($errorResult));
+                self::fail('Unexpected error result: ' . get_class($errorResult));
             }
         }
     }
@@ -148,12 +148,12 @@ class PackageValidatorTest extends TestCase
             $dependencyList->reveal()
         );
 
-        $this->assertCount(1, $errorResultList);
+        self::assertCount(1, $errorResultList);
         foreach ($errorResultList as $errorResult) {
             if ($errorResult instanceof ErrorVersionMismatchResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test2');
+                self::assertEquals($errorResult->getPackageName(), 'test2');
             } else {
-                $this->fail('Unexpected error result: ' . get_class($errorResult));
+                self::fail('Unexpected error result: ' . get_class($errorResult));
             }
         }
     }
@@ -195,12 +195,12 @@ class PackageValidatorTest extends TestCase
             $dependencyList->reveal()
         );
 
-        $this->assertCount(1, $errorResultList);
+        self::assertCount(1, $errorResultList);
         foreach ($errorResultList as $errorResult) {
             if ($errorResult instanceof ErrorVersionMismatchResult) {
-                $this->assertEquals($errorResult->getPackageName(), 'test1');
+                self::assertEquals($errorResult->getPackageName(), 'test1');
             } else {
-                $this->fail('Unexpected error result: ' . get_class($errorResult));
+                self::fail('Unexpected error result: ' . get_class($errorResult));
             }
         }
     }

--- a/tests/Validator/StrictModeTest.php
+++ b/tests/Validator/StrictModeTest.php
@@ -13,7 +13,7 @@ class StrictModeTest extends TestCase
     {
         $strictMode = StrictMode::lockedOnly();
 
-        $this->assertTrue(
+        self::assertTrue(
             $strictMode->isLockedOnly(),
             'strict mode should be locked only'
         );
@@ -22,7 +22,7 @@ class StrictModeTest extends TestCase
     {
         $strictMode = StrictMode::existingOrLocked();
 
-        $this->assertTrue(
+        self::assertTrue(
             $strictMode->isExistingOrLocked(),
             'strict mode should be existing or locked'
         );
@@ -32,7 +32,7 @@ class StrictModeTest extends TestCase
     {
         $strictMode = StrictMode::majorAndMinor();
 
-        $this->assertTrue(
+        self::assertTrue(
             $strictMode->isMajorAndMinor(),
             'strict mode should be major and minor'
         );
@@ -42,7 +42,7 @@ class StrictModeTest extends TestCase
     {
         $strictMode = StrictMode::fullSemVerMatch();
 
-        $this->assertTrue(
+        self::assertTrue(
             $strictMode->isFullSemVerMatch(),
             'strict mode should be full semantic versioning match'
         );

--- a/tests/Writer/MarkdownWriterTest.php
+++ b/tests/Writer/MarkdownWriterTest.php
@@ -11,22 +11,24 @@ use DepDoc\Writer\MarkdownWriter;
 use DepDoc\Writer\WriterConfiguration;
 use phpmock\prophecy\PHPProphet;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MarkdownWriterTest extends TestCase
 {
-    /** @var PHPProphet */
-    protected $prophet;
+    use ProphecyTrait;
+
+    protected PHPProphet $globalProphet;
 
     protected function setUp(): void
     {
-        $this->prophet = new PHPProphet();
+        $this->globalProphet = new PHPProphet();
     }
 
     public function testItSuccessfullyCreatesFileData(): void
     {
         $filepath = '/some/file';
 
-        $prophecy = $this->prophet->prophesize('DepDoc\\Writer');
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\Writer');
 
         $installedPackages = $this->prophesize(PackageManagerPackageList::class);
         $dependencyList = $this->prophesize(PackageManagerPackageList::class);
@@ -71,7 +73,7 @@ class MarkdownWriterTest extends TestCase
         $configuration->isExportExternalLink()->willReturn(true)->shouldBeCalledTimes(6);
         $configuration->getNewline()->willReturn('#nl')->shouldBeCalledTimes(26);
 
-        $prophecy->file_put_contents($filepath, [
+        $globalProphecy->file_put_contents($filepath, [
             '# Composer#nl',
             '#nl',
             '## t1p1 `1.0.0` [link](https://packagist.org/packages/t1p1)#nl',
@@ -100,7 +102,7 @@ class MarkdownWriterTest extends TestCase
             '#nl',
         ], LOCK_EX)->shouldBeCalled();
 
-        $prophecy->reveal();
+        $globalProphecy->reveal();
 
         $writer = new MarkdownWriter($configuration->reveal());
         $writer->createDocumentation(
@@ -109,7 +111,7 @@ class MarkdownWriterTest extends TestCase
             $dependencyList->reveal()
         );
 
-        $this->prophet->checkPredictions();
+        $this->globalProphet->checkPredictions();
     }
 
     protected function getComposerPackageProphecy(string $name, string $version, ?string $description)

--- a/tests/Writer/MarkdownWriterTest.php
+++ b/tests/Writer/MarkdownWriterTest.php
@@ -17,12 +17,12 @@ class MarkdownWriterTest extends TestCase
     /** @var PHPProphet */
     protected $prophet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->prophet = new PHPProphet();
     }
 
-    public function testItSuccessfullyCreatesFileData()
+    public function testItSuccessfullyCreatesFileData(): void
     {
         $filepath = '/some/file';
 


### PR DESCRIPTION
THis PR adds support for the new "extraneous" package sin NPM 7.
It also excludes peer dependencies from the installed package list, as reported by NPM <= 6.

To use the newer PHPUnit version I've upgrades also the minimum PHP version to 7.4.
@cheeZery you may have to update your travis CI pipeline to reflect that change 😊 