### PR TITLE
allow next version of symfony console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-pcre": "*",
-        "symfony/console": "^4.1",
+        "symfony/console": "^4.1 | ^5.0",
         "symfony/yaml": "^4.1",
         "symfony/serializer": "^4.1",
         "symfony/property-access": "^4.1",


### PR DESCRIPTION
Wird für laminas-cli benötigt.