### PR TITLE
Fallback for missing package descriptions with NPM 8

### DIFF
--- a/tests/PackageManager/NodePackageManagerTest.php
+++ b/tests/PackageManager/NodePackageManagerTest.php
@@ -96,4 +96,53 @@ JSON
         $packages = $manager->getInstalledPackages($targetDirectory);
         self::assertCount(0, $packages->getAllFlat(), 'there should be no packages');
     }
+
+
+    public function testDescriptionFallback(): void
+    {
+        $globalProphecy = $this->globalProphet->prophesize('DepDoc\\PackageManager');
+
+        $targetDirectory = '/some/dir';
+        $command = 'cd ' . escapeshellarg($targetDirectory) . ' && npm list --json --depth 0 --long 2> /dev/null';
+        $globalProphecy
+            ->shell_exec($command)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(<<<JSON
+{
+  "dependencies": {
+    "TestWithMissingDescription": {
+      "name": "TestWithMissingDescription",
+      "version": "1.0.0",
+      "path": "/somewhere/node_modules/TestWithMissingDescription"
+    }
+  }
+}
+JSON
+            );
+
+        $globalProphecy
+            ->file_get_contents('/somewhere/node_modules/TestWithMissingDescription/package.json')
+            ->shouldBeCalledTimes(1)
+            ->willReturn(<<<JSON
+{
+  "name": "TestWithMissingDescription",
+  "version": "1.0.0",
+  "description": "foo bar"
+}
+JSON
+            );
+
+        $globalProphecy->reveal();
+        $manager = new NodePackageManager();
+
+        $packages = $manager->getInstalledPackages($targetDirectory);
+        self::assertCount(1, $packages->getAllFlat());
+        self::assertTrue($packages->has($manager->getName(), 'TestWithMissingDescription'));
+
+        /** @var NodePackage $package */
+        $package = $packages->get($manager->getName(), 'TestWithMissingDescription');
+        self::assertEquals('TestWithMissingDescription', $package->getName());
+        self::assertEquals('1.0.0', $package->getVersion());
+        self::assertEquals('foo bar', $package->getDescription());
+    }
 }


### PR DESCRIPTION
On some NPM installations above NPM 8, description fields won't be returned from the `npm list --json --depth 0 --long` command. I wasn't able to pinpoint the cause as some colleagues are missing the descriptions and some don't, even on identical NPM versions 🤷‍♂️ 

`npm list` does however return a path to the package's directory where we can find it's `package.json` that is still containing the description. 
In cases where `npm list` isn't returning descriptions, the `NodePackageManager` will try to read them out of the package's `package.json` instead.