### PR TITLE
Replace deprecated package for semantic versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/dependency-injection": "^4.4 | ^5.4 | ^6.0",
         "composer/composer": "^2.0",
         "symfony/config": "^4.4 | ^5.4 | ^6.0",
-        "vierbergenlars/php-semver": "^3.0.2"
+        "z4kn4fein/php-semver": "^2.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/src/Validator/PackageValidator.php
+++ b/src/Validator/PackageValidator.php
@@ -10,7 +10,7 @@ use DepDoc\Validator\Result\ErrorDocumentedButNotInstalledResult;
 use DepDoc\Validator\Result\ErrorMissingDocumentationResult;
 use DepDoc\Validator\Result\ErrorResultInterface;
 use DepDoc\Validator\Result\ErrorVersionMismatchResult;
-use vierbergenlars\SemVer\version;
+use z4kn4fein\SemVer\Version;
 
 class PackageValidator
 {
@@ -89,8 +89,8 @@ class PackageValidator
         }
 
         if ($mode->isMajorAndMinor()) {
-            $dependencyVersion = new version($dependency->getVersion());
-            $packageVersion = new version($package->getVersion());
+            $dependencyVersion = Version::parse($dependency->getVersion());
+            $packageVersion = Version::parse($package->getVersion());
 
             return (
                 $dependencyVersion->getMajor() === $packageVersion->getMajor()

--- a/src/Validator/PackageValidator.php
+++ b/src/Validator/PackageValidator.php
@@ -89,8 +89,8 @@ class PackageValidator
         }
 
         if ($mode->isMajorAndMinor()) {
-            $dependencyVersion = Version::parse($dependency->getVersion());
-            $packageVersion = Version::parse($package->getVersion());
+            $dependencyVersion = Version::parse($dependency->getVersion(), false);
+            $packageVersion = Version::parse($package->getVersion(), false);
 
             return (
                 $dependencyVersion->getMajor() === $packageVersion->getMajor()


### PR DESCRIPTION
The package `vierbergenlars/php-semver` is deprecated, it suggests to use `composer/semver` but that packages does not solve our needs as it only has comparison functions not parsing functions. 

So I used another maintained package. 